### PR TITLE
Clear draggingMarkerKey to avoid unintentional onClick calls on mouse up

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -323,8 +323,8 @@ export default class Map extends React.Component {
       new Date() > this.clickTime + this.props.minDragTime
     ) {
       this.dragEnd(this.draggingMarkerKey)
-      this.draggingMarkerKey = null
     }
+    this.draggingMarkerKey = null
     this.clickPoint = null
     this.dragged = false
     this.redraw()


### PR DESCRIPTION
After clicking on a marker, the `draggingMarkerKey` was sometimes persisting on the map. This meant subsequent `canvasMouseUp` calls on the blank canvas would still see the marker as selected and run its `onClick`

- [x] Updated the `documentMouseUpListener` to always clean the `draggingMarkerKey`, instead of only when it was being dragged